### PR TITLE
Fix Compact "Navbar Temperature Plugin" apperance

### DIFF
--- a/octoprint_uicustomizer/static/css/uicustomizer.css
+++ b/octoprint_uicustomizer/static/css/uicustomizer.css
@@ -837,7 +837,7 @@ body.UICResponsiveMode select{
     display:inline-block;
     margin-top: 2px;
     padding-left: 27px;
-    text-indent: -40px;
+    text-indent: -38px;
     overflow: hidden;
     height: 40px;
     padding-top: 6px;
@@ -845,7 +845,7 @@ body.UICResponsiveMode select{
 }
 #navbar_plugin_navbartemp.UICIconHack #socInfo{
     max-width: 49px;
-    text-indent: -58px;
+    text-indent: -54px;
 }
 
 #navbar_plugin_navbartemp.UICIconHack > div > span:after{


### PR DESCRIPTION
In the previous version, the temperature text was truncated.

before:
![image](https://user-images.githubusercontent.com/37847362/117158599-d80cac00-adbf-11eb-81a2-82d4b5c89333.png)

after:
![image](https://user-images.githubusercontent.com/37847362/117158337-9aa81e80-adbf-11eb-9014-bb0b2c87c36f.png)
