### PR TITLE
Fixed Spelling

### DIFF
--- a/octoprint_uicustomizer/templates/uicustomizer_settings.jinja2
+++ b/octoprint_uicustomizer/templates/uicustomizer_settings.jinja2
@@ -27,7 +27,7 @@
                 <div class="row-fluid">
                     <div class="span6">
                         <div class="controls">
-                            <label class="checkbox" title="Enables the improved responsive mode including settings for mobile/tables"><input data-bind="checked: settings.plugins.uicustomizer.responsiveMode" data-settingtype="responsiveMode" type="checkbox"> {{ _('Improve mobile/responsive') }}</label>
+                            <label class="checkbox" title="Enables the improved responsive mode including settings for mobile/tablets"><input data-bind="checked: settings.plugins.uicustomizer.responsiveMode" data-settingtype="responsiveMode" type="checkbox"> {{ _('Improve mobile/responsive') }}</label>
                         </div>
                         <div class="controls">
                             <label class="checkbox" title="Should the top menubar stay fixed when scrolling or not"><input data-bind="checked: settings.plugins.uicustomizer.fixedHeader" data-settingtype="fixedHeader" type="checkbox"> {{ _('Fixed header/topbar') }}</label>


### PR DESCRIPTION
The description of the "Improved mobile/responsive" option has a spelling error in it. Changed "tables" to "tablets."